### PR TITLE
feature/continue-script-when-push-errors

### DIFF
--- a/scripts/legacy/migrazione_git_repo.sh
+++ b/scripts/legacy/migrazione_git_repo.sh
@@ -22,8 +22,6 @@ set -euo pipefail
 # - Se la repo esiste già in destinazione, il push NON viene eseguito a meno di usare --force-push.
 #
 # Autore: Antonio Musarra <antonio.musarra@gmail.com>
-# Date: 2024-09-16
-# Version: 1.0.1
 #
 
 SRC_ORG=""


### PR DESCRIPTION
Risoluzione della issue #2.

In caso di errori in fase di push, l'esecuzione dello script non deve essere interrotta e continuare con il resto del processo di migrazione.